### PR TITLE
fix: docker image must be rebuild before e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -71,11 +71,11 @@ shell-orvd:
 shell-orvd-real:
 	docker run --volume="`pwd`:/home/user/" --name orvd -w /home/user/orvd --net simulator -p 8080:8080 --ip 172.28.0.4 -it --rm orvd /bin/bash -i
 
-e2e-offline:
+e2e-offline: docker-image
 	docker-compose -f tests/e2e-offline-docker-compose.yml up --abort-on-container-exit --exit-code-from mavproxy
 	docker-compose -f tests/e2e-offline-docker-compose.yml down
 
-e2e-online:
+e2e-online: docker-image
 	docker-compose -f tests/e2e-online-docker-compose.yml up --abort-on-container-exit --exit-code-from mavproxy
 	docker-compose -f tests/e2e-online-docker-compose.yml down
 


### PR DESCRIPTION
docker image must be rebuild before e2e tests